### PR TITLE
install db and req files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,10 @@
-autosave (5.7.1-1) UNRELEASED; urgency=medium
+autosave (5.7.1-1) unstable; urgency=medium
 
+  [ mdavidsaver ]
   * initial
 
- --  mdavidsaver <mdavidsaver@gmail.com>  Thu, 10 Mar 2016 14:44:39 -0500
+  [ chabot ]
+  * install db and req files
+  * update packaging
+
+ -- Daron Chabot <chabot@frib.msu.edu>  Thu, 19 May 2016 16:28:32 -0400

--- a/debian/patches/0003-install-db-and-req-files.patch
+++ b/debian/patches/0003-install-db-and-req-files.patch
@@ -1,0 +1,29 @@
+From 6c5a4aeadeb08035a51ed22f7a3169b0f1564ac5 Mon Sep 17 00:00:00 2001
+From: Daron Chabot <chabot@frib.msu.edu>
+Date: Thu, 19 May 2016 15:32:16 -0400
+Subject: [PATCH] install db and req files
+
+---
+ asApp/Db/Makefile | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/asApp/Db/Makefile b/asApp/Db/Makefile
+index 983981d..5b2eb6f 100644
+--- a/asApp/Db/Makefile
++++ b/asApp/Db/Makefile
+@@ -10,7 +10,11 @@ include $(TOP)/configure/CONFIG
+ #----------------------------------------------------
+ # Create and install (or just install) into <top>/db
+ # databases, templates, substitutions like this
+-#DB += xxx.db
++DB += save_restoreStatus.db
++DB += configMenu.db
++DB += configMenu.req
++DB += configMenuNames.req
++DB += configMenu_settings.req
+ 
+ #----------------------------------------------------
+ # If <anyname>.db template is not named <anyname>*.template add
+-- 
+2.1.4
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 0001-RELEASE.patch
 0002-fixup-format-warning.patch
+0003-install-db-and-req-files.patch


### PR DESCRIPTION
Addresses #1.

Note that this PR installs *.req files into /usr/lib/epics/db.
Other synApps modules appear to install req files into /usr/lib/epics/as/req...
