### PR TITLE
Use build profile to enable RTEMS cross build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+autosave (5.8-2) unstable; urgency=medium
+
+  * Use build profile to enable RTEMS cross build
+
+ -- Martin Konrad <konrad@frib.msu.edu>  Thu, 13 Sep 2018 13:57:26 -0400
+
 autosave (5.8-1) unstable; urgency=medium
 
   * New upstream version 5.8

--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,12 @@ Source: autosave
 Section: libdevel
 Priority: extra
 Maintainer: mdavidsaver <mdavidsaver@gmail.com>
-Build-Depends: debhelper (>= 9), epics-debhelper (>= 8.14~),
-               epics-dev,
-               rtems-epics-mvme2100,
-               rtems-epics-mvme3100,
-               rtems-epics-mvme5500,
-               rtems-epics-pc386,
+Build-Depends: debhelper (>= 9.20141010), dpkg-dev (>= 1.17.14),
+               epics-debhelper (>= 8.14~), epics-dev,
+               rtems-epics-mvme2100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme3100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme5500 <pkg.epics-base.rtems>,
+               rtems-epics-pc386 <pkg.epics-base.rtems>,
 XS-Rtems-Build-Depends: rtems-epics
 Standards-Version: 3.9.6
 Homepage: http://aps.anl.gov/bcda/synApps/autosave/autosave.html
@@ -35,6 +35,7 @@ Description: Bump-less reboot for IOCs
  This package contains runtime libraries
 
 Package: rtems-autosave-mvme2100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-autosave-dev (>= ${source:Version}),
          epics-autosave-dev (<< ${source:Version}.1~),
@@ -46,6 +47,7 @@ Description: Bump-less reboot for IOCs
  This package contains support for the MVME2100 VME SBC
 
 Package: rtems-autosave-mvme3100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-autosave-dev (>= ${source:Version}),
          epics-autosave-dev (<< ${source:Version}.1~),
@@ -57,6 +59,7 @@ Description: Bump-less reboot for IOCs
  This package contains support for the MVME3100 VME SBC
 
 Package: rtems-autosave-mvme5500
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-autosave-dev (>= ${source:Version}),
          epics-autosave-dev (<< ${source:Version}.1~),
@@ -68,6 +71,7 @@ Description: Bump-less reboot for IOCs
  This package contains support for the MVME5500 VME SBC
 
 Package: rtems-autosave-pc386
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-autosave-dev (>= ${source:Version}),
          epics-autosave-dev (<< ${source:Version}.1~),

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,8 @@
+autosave source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-autosave-mvme2100
+autosave source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-autosave-mvme3100
+autosave source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-autosave-mvme5500
+autosave source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-autosave-pc386
+autosave source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2100 <pkg.epics-base.rtems>]
+autosave source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme3100 <pkg.epics-base.rtems>]
+autosave source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme5500 <pkg.epics-base.rtems>]
+autosave source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-pc386 <pkg.epics-base.rtems>]


### PR DESCRIPTION
This allows facilities that do not use RTEMS to get rid of the complexity of building this package's RTEMS dependencies. Set the environment variable `DEB_BUILD_PROFILES=pkg.epics-base.rtems` when compiling to enable the RTEMS build.